### PR TITLE
レートリミット時の処理修正、ピン留め解除時のエラー修正等

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,23 @@
 <template>
-  <div class="maintenance-container" style="background-image: url('/wallpaper.jpg')">
+  <div
+    class="maintenance-container"
+    style="background-image: url('/wallpaper.jpg')"
+  >
     <div class="background-overlay" />
-    
+
     <div class="maintenance-card">
       <div class="glass-effect" />
 
       <div class="icon-container">
         <div class="icon-wrapper">
           <div class="maintenance-icon">
-            <img src="/favicon.ico" alt="Logo" class="favicon-icon" width="64" height="64" />
+            <img
+              src="/favicon.ico"
+              alt="Logo"
+              class="favicon-icon"
+              width="64"
+              height="64"
+            />
           </div>
         </div>
       </div>
@@ -44,11 +53,7 @@
           />
         </div>
 
-        <button
-          type="submit"
-          :disabled="isLoading"
-          class="submit-button"
-        >
+        <button type="submit" :disabled="isLoading" class="submit-button">
           <Loader2 v-if="isLoading" class="icon" />
           <Trash2 v-else class="icon" />
           {{ isLoading ? '処理中...' : 'クリーンアップを開始' }}
@@ -101,14 +106,18 @@ const handleSubmit = async () => {
 
   try {
     const api = new MisskeyAPI(host.value, token.value);
-    
+
     // Fetch user info
     const user = await api.getUser();
-    status.value = `アカウントを確認:\n ${user.name ?? user.username} @${user.username}\n ${user.notesCount} ノート\n ID: ${user.id}`;
-    
+    status.value = `アカウントを確認:\n ${user.name ?? user.username} @${
+      user.username
+    }\n ${user.notesCount} ノート\n ID: ${user.id}`;
+
     // Unpin notes
     if (user.pinnedNotes?.length) {
-      console.log(`${user.pinnedNotes.length}個のピン留めされたノートを見つけました`);
+      console.log(
+        `${user.pinnedNotes.length}個のピン留めされたノートを見つけました`
+      );
       for (const note of user.pinnedNotes) {
         if (note.id) {
           await api.unpinNote(note.id);
@@ -128,13 +137,14 @@ const handleSubmit = async () => {
       for (const note of notes) {
         if (note.id) {
           try {
-            await api.deleteNote(note.id);
-            deleted++;
+            await api.deleteNote(note.id).then(() => deleted++);
             progress.value.deleted = deleted;
             progress.value.total = user.notesCount;
             console.log(`ノートを削除: ${note.toString()}`);
           } catch (error) {
-            console.error(`ノート ${note.id} の削除に失敗: ${(error as Error).message}`);
+            console.error(
+              `ノート ${note.id} の削除に失敗: ${(error as Error).message}`
+            );
           }
         }
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -32,6 +32,11 @@ export class MisskeyAPI {
         throw new Error(error.message || 'API request failed');
       }
 
+      //? return empty json
+      if (response.status == 204) {
+        return {} as T;
+      }
+
       return response.json();
     } catch (error) {
       console.error(`API request failed for ${path}:`, error);

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,7 +45,7 @@ export class MisskeyAPI {
   }
 
   async unpinNote(noteId: string): Promise<void> {
-    await this.post('notes/unpin', { noteId });
+    await this.post('i/unpin', { noteId });
   }
 
   async deleteNote(noteId: string): Promise<void> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { User, Note, MisskeyError } from './types';
+import type { User, Note, MisskeyError, MisskeyRateLimited } from './types';
 
 export class MisskeyAPI {
   private endpoint: string;
@@ -20,7 +20,16 @@ export class MisskeyAPI {
       });
 
       if (!response.ok) {
-        const error = await response.json() as MisskeyError;
+        if (response.status == 429) {
+          const error = ((await response.json()) as MisskeyRateLimited).error;
+          const now = Date.now();
+          const diff = (error.info.resetMs ?? 1000 * 10) - now;
+          console.error(`Ratelimited. retrying after ${diff / 1000}second...`);
+          setTimeout(() => {
+            this.post(path, content);
+          }, diff);
+        }
+        const error = (await response.json()) as MisskeyError;
         throw new Error(error.message || 'API request failed');
       }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,9 +25,8 @@ export class MisskeyAPI {
           const now = Date.now();
           const diff = (error.info.resetMs ?? 1000 * 10) - now;
           console.error(`Ratelimited. retrying after ${diff / 1000}second...`);
-          setTimeout(() => {
-            this.post(path, content);
-          }, diff);
+          await new Promise((_) => setTimeout(_, diff));
+          return await this.post(path, content);
         }
         const error = (await response.json()) as MisskeyError;
         throw new Error(error.message || 'API request failed');

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,16 +22,37 @@ export interface Note {
 }
 
 export const noteToString = (note: Note): string => {
-  const text = note.cw || note.text || "(No text)";
+  const text = note.cw || note.text || '(No text)';
   const renoteText = note.renote ? ` RN: ${noteToString(note.renote)}` : '';
   const replyText = note.reply ? ` RE: ${noteToString(note.reply)}` : '';
-  const mediaText = note.mediaIds?.length ? ` (${note.mediaIds.length} medias)` : '';
+  const mediaText = note.mediaIds?.length
+    ? ` (${note.mediaIds.length} medias)`
+    : '';
   return `${text}${renoteText}${replyText}${mediaText}`;
 };
 
+/** [API Doc](https://misskey.io/api-doc) */
 export interface MisskeyError {
   message?: string;
   code?: string;
   id?: string;
   kind?: string;
+}
+
+/** [API Doc](https://misskey.io/api-doc) */
+export interface MisskeyRateLimited {
+  error: {
+    message: string;
+    code: string;
+    id: string;
+    kind: string;
+    info: {
+      remaining: number;
+      /** Unix Second */
+      reset: number;
+      /** Unix Milisecond */
+      resetMs: number;
+      total: number;
+    };
+  };
 }


### PR DESCRIPTION
レートリミットを安全に処理し、その他仕様変更等によって発生していた問題を修正しました。

# 変更内容
* レートリミット発生時にレスポンスから返却されている情報を使い、指定された時間待機後再試行するようにしました。この変更に伴い、`MisskeyRateLimited`型が追加されています。
* APIの仕様変更により、`/notes/unpin`ではなく`/i/unpin`が使われるようになりました。これに合わせた修正も行われております。
* APIから`204 No Content`が返却された場合、それをJSONでパースしようとして失敗する問題が発生していました。動作に支障はありませんが目障りなのでレスポンスのコードが204である場合は空のオブジェクト(`{}`)を返却するようになっています。
* `deleted++`の処理を`.then()`内に移動(処理への影響はなし)

その他細かい変更点については変更履歴を確認してください。

# 備考

* ステータスバッジ等のテキストカラーが非常に見にくいので、直したい(こだわりがなければやっちゃう)